### PR TITLE
feat: make_github_release, run_pytest, pypi_release | fix: devcontainer-build yq syntax

### DIFF
--- a/.github/workflows/devcontainer-build.yaml
+++ b/.github/workflows/devcontainer-build.yaml
@@ -17,7 +17,7 @@ jobs:
         echo "PIP_PACKAGE_NAME=${PIP_PACKAGE_NAME}" >> $GITHUB_ENV
     - name: Build image
       run: |
-        IMAGE=$(yq r ./.devcontainer/local/docker-compose.yaml 'services.app.image')
+        IMAGE=$(yq eval '.services.app.image' ./.devcontainer/local/docker-compose.yaml)
         docker build -t "${IMAGE}" -f ./.devcontainer/Dockerfile .
         docker save "${IMAGE}" | \
             gzip > "image-devcontainer-${PIP_PACKAGE_NAME}.tar.gz"

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -30,11 +30,11 @@ jobs:
         with:
           path: ./CHANGELOG.md
           version: ${{env.PKG_VERSION}}
-      # - name: Delete tag and release
-      #   uses: dev-drprasad/delete-tag-and-release@v1.0
-      #   with:
-      #     tag_name: ${{steps.changelog_reader.outputs.version}}
-      #     github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: cardinalby/git-get-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag: '1.2.3' 
       - name: Create GH release
         id: create_gh_release
         uses: actions/create-release@v1

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -3,13 +3,13 @@ on:
   workflow_call:
     outputs:
       release_upload_url:
-        value: ${{ jobs.make_github_release.outputs.gh_release_upload_url }}
+        value: ${{ jobs.make_github_release.outputs.gh_release_upload_url }}  
 
 jobs:
   make_github_release:
     runs-on: ubuntu-latest
     outputs:
-      gh_release_upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
+      gh_release_upload_url: ${{ steps.get_release_upload_url.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python
@@ -56,6 +56,3 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           tag: ${{steps.changelog_reader.outputs.version}}
-      - name: Output release upload URL
-        run: |
-          echo "gh_release_upload_url = ${{steps.get_release_upload_url.outputs.upload_url}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -30,13 +30,14 @@ jobs:
         with:
           path: ./CHANGELOG.md
           version: ${{env.PKG_VERSION}}
-      - uses: cardinalby/git-get-release-action@v1
+      - name: Check if release already exists
+        uses: cardinalby/git-get-release-action@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          tag: '1.2.3' 
+          tag: ${{steps.changelog_reader.outputs.version}}
       - name: Create GH release
-        id: create_gh_release
+        if: failure() || steps.check_release.outputs.release_id == ''
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
@@ -46,6 +47,13 @@ jobs:
           body: ${{steps.changelog_reader.outputs.changes}}
           prerelease: ${{steps.changelog_reader.outputs.status == 'prereleased'}}
           draft: ${{steps.changelog_reader.outputs.status == 'unreleased'}}
-      - name: Get GH release upload URL
+      - name: Get release upload URL
+        id: get_release_upload_url
+        uses: cardinalby/git-get-release-action@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag: ${{steps.changelog_reader.outputs.version}}
+      - name: Output release upload URL
         run: |
-          echo "gh_release_upload_url = ${{steps.create_gh_release.outputs.upload_url}}" >> $GITHUB_OUTPUT
+          echo "gh_release_upload_url = ${{steps.get_release_upload_url.outputs.upload_url}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -39,7 +39,7 @@ jobs:
           tag: ${{steps.changelog_reader.outputs.version}}
         continue-on-error: true
       - name: Create GH release
-        if: failure() && steps.check_release.outputs.id == ''
+        if: failure()
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -31,6 +31,7 @@ jobs:
           path: ./CHANGELOG.md
           version: ${{env.PKG_VERSION}}
       - name: Check if release already exists
+        id: check_release
         uses: cardinalby/git-get-release-action@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
@@ -38,7 +39,7 @@ jobs:
           tag: ${{steps.changelog_reader.outputs.version}}
         continue-on-error: true
       - name: Create GH release
-        if: failure() || steps.check_release.outputs.release_id == ''
+        if: failure() && steps.check_release.outputs.id == ''
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -30,6 +30,10 @@ jobs:
         with:
           path: ./CHANGELOG.md
           version: ${{env.PKG_VERSION}}
+      - uses: dev-drprasad/delete-tag-and-release@v1.0
+        with:
+          tag_name: ${{steps.changelog_reader.outputs.version}}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GH release
         id: create_gh_release
         uses: actions/create-release@v1

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -12,7 +12,10 @@ jobs:
       gh_release_upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
       - name: Determine package version
         run: |
           PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if '.' not in p][0])")

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Create GH release
         id: create_gh_release
         uses: actions/create-release@v1
-        if: ${{ !contains(env.TWINE_REPO, 'testpypi') }}
+        if: success() || failure()
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -37,8 +37,9 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           tag: ${{steps.changelog_reader.outputs.version}}
+        continue-on-error: true
       - name: Create GH release
-        if: failure()
+        if: steps.check_release.outputs.id == ''
         uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -30,7 +30,8 @@ jobs:
         with:
           path: ./CHANGELOG.md
           version: ${{env.PKG_VERSION}}
-      - uses: dev-drprasad/delete-tag-and-release@v1.0
+      - name: Delete tag and release
+        uses: dev-drprasad/delete-tag-and-release@v1.0
         with:
           tag_name: ${{steps.changelog_reader.outputs.version}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -41,7 +42,7 @@ jobs:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:
           tag_name: ${{steps.changelog_reader.outputs.version}}
-          release_name: Release ${{steps.changelog_reader.outputs.version}}
+          release_name: ${{steps.changelog_reader.outputs.version}}
           body: ${{steps.changelog_reader.outputs.changes}}
           prerelease: ${{steps.changelog_reader.outputs.status == 'prereleased'}}
           draft: ${{steps.changelog_reader.outputs.status == 'unreleased'}}

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -12,10 +12,7 @@ jobs:
       gh_release_upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python ${{matrix.py_ver}}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{matrix.py_ver}}
+      - uses: actions/setup-python@v4
       - name: Determine package version
         run: |
           PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if '.' not in p][0])")

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -37,7 +37,6 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           tag: ${{steps.changelog_reader.outputs.version}}
-        continue-on-error: true
       - name: Create GH release
         if: failure()
         uses: actions/create-release@v1

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -36,6 +36,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           tag: ${{steps.changelog_reader.outputs.version}}
+        continue-on-error: true
       - name: Create GH release
         if: failure() || steps.check_release.outputs.release_id == ''
         uses: actions/create-release@v1

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -37,7 +37,6 @@ jobs:
       - name: Create GH release
         id: create_gh_release
         uses: actions/create-release@v1
-        if: success() || failure()
         env:
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
         with:

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -1,0 +1,47 @@
+name: make_github_release
+on:
+  workflow_call:
+    outputs:
+      release_upload_url:
+        value: ${{ jobs.make_github_release.outputs.gh_release_upload_url }}
+
+jobs:
+  make_github_release:
+    runs-on: ubuntu-latest
+    outputs:
+      gh_release_upload_url: ${{ steps.create_gh_release.outputs.upload_url }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{matrix.py_ver}}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.py_ver}}
+      - name: Determine package version
+        run: |
+          PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if '.' not in p][0])")
+          SDIST_PKG_NAME=$(echo ${PKG_NAME} | sed 's|_|-|g')
+          PKG_VERSION=$(cat ${PKG_NAME}/version.py | grep -oP '\d+\.\d+\.[a-z0-9]+')
+          echo "PKG_NAME=${PKG_NAME}" >> $GITHUB_ENV
+          echo "PKG_VERSION=${PKG_VERSION}" >> $GITHUB_ENV
+          echo "SDIST_PKG_NAME=${SDIST_PKG_NAME}" >> $GITHUB_ENV
+      - name: Get changelog entry
+        id: changelog_reader
+        uses: guzman-raphael/changelog-reader-action@v5
+        with:
+          path: ./CHANGELOG.md
+          version: ${{env.PKG_VERSION}}
+      - name: Create GH release
+        id: create_gh_release
+        uses: actions/create-release@v1
+        if: ${{ !contains(env.TWINE_REPO, 'testpypi') }}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          tag_name: ${{steps.changelog_reader.outputs.version}}
+          release_name: Release ${{steps.changelog_reader.outputs.version}}
+          body: ${{steps.changelog_reader.outputs.changes}}
+          prerelease: ${{steps.changelog_reader.outputs.status == 'prereleased'}}
+          draft: ${{steps.changelog_reader.outputs.status == 'unreleased'}}
+      - name: Get GH release upload URL
+        run: |
+          echo "gh_release_upload_url = ${{steps.create_gh_release.outputs.upload_url}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -30,11 +30,11 @@ jobs:
         with:
           path: ./CHANGELOG.md
           version: ${{env.PKG_VERSION}}
-      - name: Delete tag and release
-        uses: dev-drprasad/delete-tag-and-release@v1.0
-        with:
-          tag_name: ${{steps.changelog_reader.outputs.version}}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+      # - name: Delete tag and release
+      #   uses: dev-drprasad/delete-tag-and-release@v1.0
+      #   with:
+      #     tag_name: ${{steps.changelog_reader.outputs.version}}
+      #     github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Create GH release
         id: create_gh_release
         uses: actions/create-release@v1

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -1,6 +1,10 @@
 name: pypi_release
 on:
   workflow_call:
+    inputs:
+      UPLOAD_URL:
+        description: 'Github Release Upload URL'
+        required: true
     secrets:
       TWINE_USERNAME:
         required: true
@@ -34,12 +38,34 @@ jobs:
       - name: Build package
         run: |
           pip install wheel && python setup.py bdist_wheel sdist
+      - name: Determine pip artifact paths
+        run: |
+          echo "PKG_WHEEL_PATH=$(ls dist/${PKG_NAME}-*.whl)" >> $GITHUB_ENV
+          echo "PKG_SDIST_PATH=$(ls dist/${SDIST_PKG_NAME}-*.tar.gz)" >> $GITHUB_ENV
+      - name: Upload pip wheel asset to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          upload_url: ${{env.UPLOAD_URL}}
+          asset_path: ${{env.PKG_WHEEL_PATH}}
+          asset_name: pip-${{env.PKG_NAME}}-${{env.PKG_VERSION}}.whl
+          asset_content_type: application/zip
+      - name: Upload pip sdist asset to release
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        with:
+          upload_url: ${{env.UPLOAD_URL}}
+          asset_path: ${{env.PKG_SDIST_PATH}}
+          asset_name: pip-${{env.SDIST_PKG_NAME}}-${{env.PKG_VERSION}}.tar.gz
+          asset_content_type: application/gzip
       - name: Publish package
         run: |
           export CHECK_EXIST=$(curl -sI https://pypi.org/project/${{env.SDIST_PKG_NAME}}/${{env.PKG_VERSION}}/ | head -n 1 | cut -d$' ' -f2)
           if [ "$CHECK_EXIST" == "404" ]; then
             echo "Uploading Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} to pypi.org"
-            pip install twine && python -m twine upload --repository testpypi ./dist/*
+            pip install twine && python -m twine upload ./dist/*
           else
             echo "Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} already exists on pypi.org"
           fi

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -1,0 +1,45 @@
+name: pypi_release
+on:
+  workflow_call:
+    secrets:
+      TWINE_USERNAME:
+        required: true
+      TWINE_PASSWORD:
+        required: true
+
+jobs:
+  pypi-release:
+  runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        py_ver: ["3.9"]
+    env:
+      TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
+      TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{matrix.py_ver}}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.py_ver}}
+      - name: Determine package version
+        run: |
+          PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if '.' not in p][0])")
+          SDIST_PKG_NAME=$(echo ${PKG_NAME} | sed 's|_|-|g')
+          PKG_VERSION=$(cat ${PKG_NAME}/version.py | grep -oP '\d+\.\d+\.[a-z0-9]+')
+          echo "PKG_NAME=${PKG_NAME}" >> $GITHUB_ENV
+          echo "PKG_VERSION=${PKG_VERSION}" >> $GITHUB_ENV
+          echo "SDIST_PKG_NAME=${SDIST_PKG_NAME}" >> $GITHUB_ENV
+      - name: Build package
+        run: |
+          pip install wheel && python setup.py bdist_wheel sdist
+      - name: Publish package
+        run: |
+          export CHECK_EXIST=$(curl -sI https://pypi.org/project/${{env.SDIST_PKG_NAME}}/${{env.PKG_VERSION}}/ | head -n 1 | cut -d$' ' -f2)
+          if [ "$CHECK_EXIST" == "404" ]; then
+            echo "Uploading Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} to pypi.org"
+            pip install twine && python -m twine upload ./dist/*
+          else
+            echo "Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} already exists on pypi.org"
+          fi

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -39,7 +39,7 @@ jobs:
           export CHECK_EXIST=$(curl -sI https://pypi.org/project/${{env.SDIST_PKG_NAME}}/${{env.PKG_VERSION}}/ | head -n 1 | cut -d$' ' -f2)
           if [ "$CHECK_EXIST" == "404" ]; then
             echo "Uploading Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} to pypi.org"
-            pip install twine && python -m twine upload ./dist/*
+            pip install twine && python -m twine upload --repository testpypi ./dist/*
           else
             echo "Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} already exists on pypi.org"
           fi

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -9,37 +9,37 @@ on:
 
 jobs:
   pypi-release:
-  runs-on: ubuntu-latest
-  strategy:
-    matrix:
-      py_ver: ["3.9"]
-  env:
-    TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
-    TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
-    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{matrix.py_ver}}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{matrix.py_ver}}
-    - name: Determine package version
-      run: |
-        PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if '.' not in p][0])")
-        SDIST_PKG_NAME=$(echo ${PKG_NAME} | sed 's|_|-|g')
-        PKG_VERSION=$(cat ${PKG_NAME}/version.py | grep -oP '\d+\.\d+\.[a-z0-9]+')
-        echo "PKG_NAME=${PKG_NAME}" >> $GITHUB_ENV
-        echo "PKG_VERSION=${PKG_VERSION}" >> $GITHUB_ENV
-        echo "SDIST_PKG_NAME=${SDIST_PKG_NAME}" >> $GITHUB_ENV
-    - name: Build package
-      run: |
-        pip install wheel && python setup.py bdist_wheel sdist
-    - name: Publish package
-      run: |
-        export CHECK_EXIST=$(curl -sI https://pypi.org/project/${{env.SDIST_PKG_NAME}}/${{env.PKG_VERSION}}/ | head -n 1 | cut -d$' ' -f2)
-        if [ "$CHECK_EXIST" == "404" ]; then
-          echo "Uploading Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} to pypi.org"
-          pip install twine && python -m twine upload --repository testpypi ./dist/*
-        else
-          echo "Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} already exists on pypi.org"
-        fi
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        py_ver: ["3.9"]
+    env:
+      TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
+      TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{matrix.py_ver}}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.py_ver}}
+      - name: Determine package version
+        run: |
+          PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if '.' not in p][0])")
+          SDIST_PKG_NAME=$(echo ${PKG_NAME} | sed 's|_|-|g')
+          PKG_VERSION=$(cat ${PKG_NAME}/version.py | grep -oP '\d+\.\d+\.[a-z0-9]+')
+          echo "PKG_NAME=${PKG_NAME}" >> $GITHUB_ENV
+          echo "PKG_VERSION=${PKG_VERSION}" >> $GITHUB_ENV
+          echo "SDIST_PKG_NAME=${SDIST_PKG_NAME}" >> $GITHUB_ENV
+      - name: Build package
+        run: |
+          pip install wheel && python setup.py bdist_wheel sdist
+      - name: Publish package
+        run: |
+          export CHECK_EXIST=$(curl -sI https://pypi.org/project/${{env.SDIST_PKG_NAME}}/${{env.PKG_VERSION}}/ | head -n 1 | cut -d$' ' -f2)
+          if [ "$CHECK_EXIST" == "404" ]; then
+            echo "Uploading Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} to pypi.org"
+            pip install twine && python -m twine upload --repository testpypi ./dist/*
+          else
+            echo "Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} already exists on pypi.org"
+          fi

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         py_ver: ["3.9"]
     env:
-      UPLOAD_URL: ${{ github.event.inputs.UPLOAD_URL }}
+      UPLOAD_URL: ${{ inputs.UPLOAD_URL }}
       TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -4,6 +4,7 @@ on:
     inputs:
       UPLOAD_URL:
         description: 'Github Release Upload URL'
+        type: string
         required: true
     secrets:
       TWINE_USERNAME:

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -10,36 +10,36 @@ on:
 jobs:
   pypi-release:
   runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        py_ver: ["3.9"]
-    env:
-      TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
-      TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
-      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{matrix.py_ver}}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{matrix.py_ver}}
-      - name: Determine package version
-        run: |
-          PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if '.' not in p][0])")
-          SDIST_PKG_NAME=$(echo ${PKG_NAME} | sed 's|_|-|g')
-          PKG_VERSION=$(cat ${PKG_NAME}/version.py | grep -oP '\d+\.\d+\.[a-z0-9]+')
-          echo "PKG_NAME=${PKG_NAME}" >> $GITHUB_ENV
-          echo "PKG_VERSION=${PKG_VERSION}" >> $GITHUB_ENV
-          echo "SDIST_PKG_NAME=${SDIST_PKG_NAME}" >> $GITHUB_ENV
-      - name: Build package
-        run: |
-          pip install wheel && python setup.py bdist_wheel sdist
-      - name: Publish package
-        run: |
-          export CHECK_EXIST=$(curl -sI https://pypi.org/project/${{env.SDIST_PKG_NAME}}/${{env.PKG_VERSION}}/ | head -n 1 | cut -d$' ' -f2)
-          if [ "$CHECK_EXIST" == "404" ]; then
-            echo "Uploading Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} to pypi.org"
-            pip install twine && python -m twine upload --repository testpypi ./dist/*
-          else
-            echo "Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} already exists on pypi.org"
-          fi
+  strategy:
+    matrix:
+      py_ver: ["3.9"]
+  env:
+    TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
+    TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{matrix.py_ver}}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{matrix.py_ver}}
+    - name: Determine package version
+      run: |
+        PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if '.' not in p][0])")
+        SDIST_PKG_NAME=$(echo ${PKG_NAME} | sed 's|_|-|g')
+        PKG_VERSION=$(cat ${PKG_NAME}/version.py | grep -oP '\d+\.\d+\.[a-z0-9]+')
+        echo "PKG_NAME=${PKG_NAME}" >> $GITHUB_ENV
+        echo "PKG_VERSION=${PKG_VERSION}" >> $GITHUB_ENV
+        echo "SDIST_PKG_NAME=${SDIST_PKG_NAME}" >> $GITHUB_ENV
+    - name: Build package
+      run: |
+        pip install wheel && python setup.py bdist_wheel sdist
+    - name: Publish package
+      run: |
+        export CHECK_EXIST=$(curl -sI https://pypi.org/project/${{env.SDIST_PKG_NAME}}/${{env.PKG_VERSION}}/ | head -n 1 | cut -d$' ' -f2)
+        if [ "$CHECK_EXIST" == "404" ]; then
+          echo "Uploading Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} to pypi.org"
+          pip install twine && python -m twine upload --repository testpypi ./dist/*
+        else
+          echo "Package: ${{env.SDIST_PKG_NAME}} Version: ${{env.PKG_VERSION}} already exists on pypi.org"
+        fi

--- a/.github/workflows/pypi_release.yaml
+++ b/.github/workflows/pypi_release.yaml
@@ -18,6 +18,7 @@ jobs:
       matrix:
         py_ver: ["3.9"]
     env:
+      UPLOAD_URL: ${{ github.event.inputs.UPLOAD_URL }}
       TWINE_USERNAME: ${{secrets.TWINE_USERNAME}}
       TWINE_PASSWORD: ${{secrets.TWINE_PASSWORD}}
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run_pytest.yaml
+++ b/.github/workflows/run_pytest.yaml
@@ -5,18 +5,18 @@ on:
 jobs:
   run_pytest:
   runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        py_ver: ["3.8","3.9"]
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{matrix.py_ver}}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{matrix.py_ver}}
-      - name: Install dependencies
-        run: python setup.py install
-      - name: Run pytest
-        run: |
-          pip install pytest
-          pytest tests/
+  strategy:
+    matrix:
+      py_ver: ["3.8","3.9"]
+  steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{matrix.py_ver}}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{matrix.py_ver}}
+    - name: Install dependencies
+      run: python setup.py install
+    - name: Run pytest
+      run: |
+        pip install pytest
+        pytest tests/

--- a/.github/workflows/run_pytest.yaml
+++ b/.github/workflows/run_pytest.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           python-version: ${{matrix.py_ver}}
       - name: Install dependencies
-        run: python setup.py install
+        run: pip install .
       - name: Run pytest
         run: |
           pip install pytest

--- a/.github/workflows/run_pytest.yaml
+++ b/.github/workflows/run_pytest.yaml
@@ -1,0 +1,22 @@
+name: run_pytest
+on:
+  workflow_call:
+
+jobs:
+  run_pytest:
+  runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        py_ver: ["3.8","3.9"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{matrix.py_ver}}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.py_ver}}
+      - name: Install dependencies
+        run: python setup.py install
+      - name: Run pytest
+        run: |
+          pip install pytest
+          pytest tests/

--- a/.github/workflows/run_pytest.yaml
+++ b/.github/workflows/run_pytest.yaml
@@ -4,19 +4,19 @@ on:
 
 jobs:
   run_pytest:
-  runs-on: ubuntu-latest
-  strategy:
-    matrix:
-      py_ver: ["3.8","3.9"]
-  steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python ${{matrix.py_ver}}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{matrix.py_ver}}
-    - name: Install dependencies
-      run: python setup.py install
-    - name: Run pytest
-      run: |
-        pip install pytest
-        pytest tests/
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        py_ver: ["3.8","3.9"]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{matrix.py_ver}}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{matrix.py_ver}}
+      - name: Install dependencies
+        run: python setup.py install
+      - name: Run pytest
+        run: |
+          pip install pytest
+          pytest tests/


### PR DESCRIPTION
- make_github_release: 
  1. a new separated reusable workflow that will check existing release before create a new one, resolves the annoying github release error. 
  2. it'll output the upload url for any following reusable workflow to upload anything, then we can save the creating artifact step to pass it around jobs/workflows
 - run_pytest: run pytest in ./tests directory
 - pypi_release: it'll build and upload .whl and dist tar.gz to github release, then release to pypi