### PR TITLE
Update `make_github_release` workflow

### DIFF
--- a/.github/workflows/make_github_release.yaml
+++ b/.github/workflows/make_github_release.yaml
@@ -18,7 +18,7 @@ jobs:
           python-version: 3.x
       - name: Determine package version
         run: |
-          PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if '.' not in p][0])")
+          PKG_NAME=$(python3 -c "print([p for p in __import__('setuptools').find_packages() if all([x not in p for x in ['.', 'tests']])][0])")
           SDIST_PKG_NAME=$(echo ${PKG_NAME} | sed 's|_|-|g')
           PKG_VERSION=$(cat ${PKG_NAME}/version.py | grep -oP '\d+\.\d+\.[a-z0-9]+')
           echo "PKG_NAME=${PKG_NAME}" >> $GITHUB_ENV


### PR DESCRIPTION
## Description
- Recently added a `tests` directory to `element-calcium-imaging`.  Now the GitHub Actions are [failing](https://github.com/datajoint/element-calcium-imaging/actions/runs/5426442629/jobs/9868490176#step:4:17) as it is looking within the `tests` directory for the `version.py`:
  ```text
  cat: tests/version.py: No such file or directory
  ```

## Changes
- [x] Update the `make_github_release.yaml` workflow to appropriately set the `PKG_NAME` to `element_calcium_imaging`, for example.